### PR TITLE
Start of systemd command tests

### DIFF
--- a/spec/common-lx/systemd_spec.rb
+++ b/spec/common-lx/systemd_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# Test various systemd commands
+
+# We should be teting a variety of systemd commands to ensure they work
+# The hostnamectl and timedatectl commands will fail partly because of:
+# https://smartos.org/bugview/OS-5304
+
+# Note that as a workaround images from 20160505 have overrides in place for
+# the systemd-hostnamed and systemd-timedated services.
+
+describe command('hostnamectl') do
+  if file('/usr/bin/hostnamectl').exists?
+    its(:exit_status) { should eq 0 }
+  end
+end
+
+describe command('timedatectl') do
+  if file('/usr/bin/timedatectl').exists?
+    its(:exit_status) { should eq 0 }
+  end
+end


### PR DESCRIPTION
Starting with hostnamectl and timedatectl

@askfongjojo Need a quick review of this and also an FYI :)

This is the start of some tests for systemd related commands. 

A few things to note:

- These tests will fail on older images due to https://smartos.org/bugview/OS-5304 (and possibly some other lx issues)
- Starting with images release 20160505, I added overrides so that the hostnamectl and timedatectl commands work (see https://github.com/joyent/centos-lx-brand-image-builder/issues/5)
- I figured out a simple way to just test on Linux distros that have systemd by checking for the existence of the respective command I want to test. I think we can use a similar method for a lot of other tests.