### PR TITLE
use 'mkdir -p' when creating directories

### DIFF
--- a/spec/common-lx/mount_tmpfs_spec.rb
+++ b/spec/common-lx/mount_tmpfs_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # Test mount commands for tmpfs
 
-describe command('mkdir /mnt/tmpfs') do
+describe command('mkdir -p /mnt/tmpfs') do
   its(:exit_status) { should eq 0 }
 end
 
@@ -41,7 +41,7 @@ describe command('rm -R /mnt/tmpfs') do
 end
 
 # size option - should accept size in bytes, k/m/g bytes 
-describe command('mkdir /mnt/ramdisk') do
+describe command('mkdir -p /mnt/ramdisk') do
   its(:exit_status) { should eq 0 }
 end
 

--- a/spec/common-lx/user_spec.rb
+++ b/spec/common-lx/user_spec.rb
@@ -11,7 +11,7 @@ if file('/etc/alpine-release').exists?
   exit
 end
 
-describe command('mkdir /home/bar') do
+describe command('mkdir -p /home/bar') do
   its(:exit_status) { should eq 0 }
 end
 
@@ -42,7 +42,7 @@ describe command('echo "bar:joypass123" | chpasswd') do
   its(:exit_status) { should eq 0 }
 end
 
-describe command('mkdir /opt/bar') do
+describe command('mkdir -p /opt/bar') do
   its(:exit_status) { should eq 0 }
 end
 


### PR DESCRIPTION
This avoids errors in cases where the parent directory is missing