### PR TITLE
Ssh config

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,9 +22,12 @@ set_property properties[host]
 
 options = Net::SSH::Config.for(host)
 
-options[:user] ||= Etc.getlogin
-
 set :host,        options[:host_name] || host
+
+# Get HostName and User value from Env Vars if available
+options[:host_name] ||= ENV['TARGET_HOST_NAME']
+options[:user] ||= ENV['TARGET_USER_NAME']
+
 set :ssh_options, options
 
 # Disable sudo

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,17 +25,8 @@ options = Net::SSH::Config.for(host)
 set :host,        options[:host_name] || host
 
 # Get HostName and User value from Env Vars if available
+# This will override options in ~/.ssh/config or /etc/ssh_config
 options[:host_name] ||= ENV['TARGET_HOST_NAME']
 options[:user] ||= ENV['TARGET_USER_NAME']
 
 set :ssh_options, options
-
-# Disable sudo
-# set :disable_sudo, true
-
-
-# Set environment variables
-# set :env, :LANG => 'C', :LC_MESSAGES => 'C' 
-
-# Set PATH
-# set :path, '/sbin:/usr/local/sbin:$PATH'


### PR DESCRIPTION
This change allows you to set the `HostName` and `User` values for a single host (such as what you'd set in `~/.ssh/config`) via environment variables.

So for instance, you can do this:

```
export TARGET_USER_NAME=root; export TARGET_HOST_NAME=the.ip.address; rake
```

Rather than have to setup a `/.ssh/config` file with the following:

```
Host centos-7-lx
  HostName the.ip.address
  User root
```

Note that this won't work if you have multiple hosts in your properties.yml file as each host will get the same HostName IP value.

Also, the EnvVars will take precedence over your ~/.ssh/config settings.

The main purpose of doing this is to make it easier to write scripts for the tests using the the [triton](https://github.com/joyent/node-triton) cli tool.

Finally, with this change we no longer assume the current unix user login is the preferred host login, so I removed `options[:user] ||= Etc.getlogin`. Typically the host login is root for most instances with the expectation of the Ubuntu Certified images that use `ubuntu` as the login. 