### PR TITLE
Change logic for skipping Alpine for certain tests

### DIFF
--- a/spec/common-lx/group_spec.rb
+++ b/spec/common-lx/group_spec.rb
@@ -3,42 +3,40 @@ require 'spec_helper'
 # Test group add/delete actions
 # Also check the presence of sudoer groups
 
-# Bail if OS is Alpine Linux
+# Don't run tests on Alpine
 # TODO: Add tests for Alpine Linux :)
-if file('/etc/alpine-release').exists?
-  exit
-end
+if ! file('/etc/alpine-release').exists?
+  describe command('groupadd foo') do
+    its(:exit_status) { should equal 0 }
+  end
 
-describe command('groupadd foo') do
-  its(:exit_status) { should equal 0 }
-end
-
-describe group('foo') do
-  it { should exist }
-end
-
-describe command('usermod -a -G foo root') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe user('root') do
-  it { should belong_to_group 'foo' }
-end
-
-describe command('groupdel foo') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe group('foo') do
-  it { should_not exist }
-end
-
-if file('/etc/debian_version').exists?
-  describe group('sudo') do
+  describe group('foo') do
     it { should exist }
   end
-elsif file('/etc/centos-release').exists?
-  describe group('wheel') do
-    it { should exist }
+
+  describe command('usermod -a -G foo root') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe user('root') do
+    it { should belong_to_group 'foo' }
+  end
+
+  describe command('groupdel foo') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe group('foo') do
+    it { should_not exist }
+  end
+
+  if file('/etc/debian_version').exists?
+    describe group('sudo') do
+      it { should exist }
+    end
+  elsif file('/etc/centos-release').exists?
+    describe group('wheel') do
+      it { should exist }
+    end
   end
 end

--- a/spec/common-lx/user_spec.rb
+++ b/spec/common-lx/user_spec.rb
@@ -5,68 +5,66 @@ require 'spec_helper'
 # commands that take user as an argument (e.g. chown)
 # 
 
-# Bail if OS is Alpine Linux
+# Don't run tests on Alpine
 # TODO: Add tests for Alpine Linux :)
-if file('/etc/alpine-release').exists?
-  exit
-end
-
-describe command('mkdir -p /home/bar') do
-  its(:exit_status) { should eq 0 }
-end
+if ! file('/etc/alpine-release').exists?
+  describe command('mkdir -p /home/bar') do
+    its(:exit_status) { should eq 0 }
+  end
 
 
-if file('/etc/debian_version').exists?
-  describe command('useradd bar -g sudo -d /home/bar') do
+  if file('/etc/debian_version').exists?
+    describe command('useradd bar -g sudo -d /home/bar') do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe user('bar') do
+      it { should exist }
+      it { should belong_to_group 'sudo' }
+      it { should have_home_directory '/home/bar' }
+    end
+  elsif file('/etc/centos-release').exists?
+    describe command('useradd bar -g wheel -d /home/bar') do
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe user('bar') do
+      it { should exist }
+      it { should belong_to_group 'wheel' }
+      it { should have_home_directory '/home/bar' }
+    end
+  end
+
+  describe command('echo "bar:joypass123" | chpasswd') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('mkdir -p /opt/bar') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('touch /opt/bar/test.sh') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('chown -R bar /opt/bar') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe file('/opt/bar/test.sh') do
+    it { should exist }
+    it { should be_writable.by_user('bar') }
+  end
+
+  describe command('rm -Rf /opt/bar && rm -Rf /home/bar') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe command('userdel bar') do
     its(:exit_status) { should eq 0 }
   end
 
   describe user('bar') do
-    it { should exist }
-    it { should belong_to_group 'sudo' }
-    it { should have_home_directory '/home/bar' }
+    it { should_not exist }
   end
-elsif file('/etc/centos-release').exists?
-  describe command('useradd bar -g wheel -d /home/bar') do
-    its(:exit_status) { should eq 0 }
-  end
-
-  describe user('bar') do
-    it { should exist }
-    it { should belong_to_group 'wheel' }
-    it { should have_home_directory '/home/bar' }
-  end
-end
-
-describe command('echo "bar:joypass123" | chpasswd') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe command('mkdir -p /opt/bar') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe command('touch /opt/bar/test.sh') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe command('chown -R bar /opt/bar') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe file('/opt/bar/test.sh') do
-  it { should exist }
-  it { should be_writable.by_user('bar') }
-end
-
-describe command('rm -Rf /opt/bar && rm -Rf /home/bar') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe command('userdel bar') do
-  its(:exit_status) { should eq 0 }
-end
-
-describe user('bar') do
-  it { should_not exist }
 end


### PR DESCRIPTION
This removes the exit approach which seems to cause all the common-lx tests to
not run on Alpine